### PR TITLE
Feature/device

### DIFF
--- a/CuRendCore/CuRendCore/CuRendCore.vcxproj
+++ b/CuRendCore/CuRendCore/CuRendCore.vcxproj
@@ -57,6 +57,7 @@
     <ClInclude Include="include\CRC_scene.h" />
     <CudaCompile Include="include\CRC_texture.cuh" />
     <CudaCompile Include="include\CRC_srv.cuh" />
+    <CudaCompile Include="include\CRC_swap_chain.cuh" />
     <ClInclude Include="include\CRC_user_input.h" />
     <CudaCompile Include="include\CRC_view.cuh" />
     <ClInclude Include="include\CRC_window.h" />
@@ -69,6 +70,7 @@
     <CudaCompile Include="src\CRC_resource.cu" />
     <CudaCompile Include="src\CRC_rtv.cu" />
     <CudaCompile Include="src\CRC_srv.cu" />
+    <CudaCompile Include="src\CRC_swap_chain.cu" />
     <CudaCompile Include="src\CRC_texture.cu" />
   </ItemGroup>
   <ItemGroup>

--- a/CuRendCore/CuRendCore/CuRendCore.vcxproj.filters
+++ b/CuRendCore/CuRendCore/CuRendCore.vcxproj.filters
@@ -136,5 +136,11 @@
     <CudaCompile Include="include\CRC_memory.cuh">
       <Filter>ヘッダー ファイル</Filter>
     </CudaCompile>
+    <CudaCompile Include="src\CRC_swap_chain.cu">
+      <Filter>ソース ファイル</Filter>
+    </CudaCompile>
+    <CudaCompile Include="include\CRC_swap_chain.cuh">
+      <Filter>ヘッダー ファイル</Filter>
+    </CudaCompile>
   </ItemGroup>
 </Project>

--- a/CuRendCore/CuRendCore/include/CRC_buffer.cuh
+++ b/CuRendCore/CuRendCore/include/CRC_buffer.cuh
@@ -57,18 +57,18 @@ class CRC_API CRCBuffer : public ICRCContainable, public ICRCCudaResource, publi
 {
 private:
     D3D11_BUFFER_DESC desc_ = {};
-    std::unique_ptr<ICRCMem> dMem = nullptr;
+    std::unique_ptr<ICRCMem> dMem_ = nullptr;
 
 public:
-    CRCBuffer() = default;
+    CRCBuffer();
+    CRCBuffer(CRC_BUFFER_DESC& desc);
     virtual ~CRCBuffer() override = default;
 
-    virtual void* const GetMem() const override { return dMem.get(); }
+    virtual void* const Get() const { return dMem_->Get();}
+    virtual void*& GetPtr() { return dMem_->GetPtr(); }
 
-    virtual const UINT& GetByteWidth() const override { return dMem->GetByteWidth(); }
+    virtual const UINT& GetByteWidth() const override { return dMem_->GetByteWidth(); }
     virtual const void GetDesc(D3D11_BUFFER_DESC* dst) override;
-
-    friend class CRCBufferFactoryL0_0;
 };
 
 class CRC_API CRCID3D11BufferFactoryL0_0 : public ICRCFactory
@@ -81,16 +81,15 @@ public:
 class CRC_API CRCID3D11Buffer : public ICRCContainable, public ICRCD3D11Resource, public ICRCBuffer
 {
 private:
-    Microsoft::WRL::ComPtr<ID3D11Buffer> d3d11Buffer;
+    Microsoft::WRL::ComPtr<ID3D11Buffer> d3d11Buffer_;
 
 public:
     CRCID3D11Buffer() = default;
     virtual ~CRCID3D11Buffer() override = default;
 
-    virtual Microsoft::WRL::ComPtr<ID3D11Resource>& GetResource() override;
+    virtual Microsoft::WRL::ComPtr<ID3D11Resource>& GetResource();
+    virtual Microsoft::WRL::ComPtr<ID3D11Buffer>& Get() { return d3d11Buffer_; }
 
     virtual const UINT& GetByteWidth() const override;
     virtual const void GetDesc(D3D11_BUFFER_DESC* dst) override;
-
-    friend class CRCID3D11BufferFactoryL0_0;
 };

--- a/CuRendCore/CuRendCore/include/CRC_buffer.cuh
+++ b/CuRendCore/CuRendCore/include/CRC_buffer.cuh
@@ -37,10 +37,10 @@ public:
     const void* SysMem() { return initialData_.pSysMem; }
 };
 
-class CRC_API CRCIBuffer
+class CRC_API ICRCBuffer
 {
 public:
-    virtual ~CRCIBuffer() = default;
+    virtual ~ICRCBuffer() = default;
 
     virtual const UINT& GetByteWidth() const = 0;
     virtual const void GetDesc(D3D11_BUFFER_DESC* dst) = 0;
@@ -53,7 +53,7 @@ public:
     virtual std::unique_ptr<ICRCContainable> Create(IDESC& desc) const override;
 };
 
-class CRC_API CRCBuffer : public ICRCContainable, public ICRCCudaResource, public CRCIBuffer
+class CRC_API CRCBuffer : public ICRCContainable, public ICRCCudaResource, public ICRCBuffer
 {
 private:
     D3D11_BUFFER_DESC desc_ = {};
@@ -78,7 +78,7 @@ public:
     virtual std::unique_ptr<ICRCContainable> Create(IDESC& desc) const override;
 };
 
-class CRC_API CRCID3D11Buffer : public ICRCContainable, public ICRCD3D11Resource, public CRCIBuffer
+class CRC_API CRCID3D11Buffer : public ICRCContainable, public ICRCD3D11Resource, public ICRCBuffer
 {
 private:
     Microsoft::WRL::ComPtr<ID3D11Buffer> d3d11Buffer;

--- a/CuRendCore/CuRendCore/include/CRC_buffer.cuh
+++ b/CuRendCore/CuRendCore/include/CRC_buffer.cuh
@@ -19,10 +19,10 @@ private:
     D3D11_SUBRESOURCE_DATA initialData_ = {};
 
 public:
-    CRC_BUFFER_DESC(Microsoft::WRL::ComPtr<ID3D11Device>& device) : device_(device) {}
+    CRC_BUFFER_DESC(Microsoft::WRL::ComPtr<ID3D11Device>& device) : d3d11Device_(device) {}
     ~CRC_BUFFER_DESC() override = default;
 
-    Microsoft::WRL::ComPtr<ID3D11Device>& device_;
+    Microsoft::WRL::ComPtr<ID3D11Device>& d3d11Device_;
 
     D3D11_BUFFER_DESC& Desc() { return desc_; }
     D3D11_SUBRESOURCE_DATA& InitialData() { return initialData_; }
@@ -46,10 +46,10 @@ public:
     virtual const void GetDesc(D3D11_BUFFER_DESC* dst) = 0;
 };
 
-class CRC_API CRCBufferFactory : public ICRCFactory
+class CRC_API CRCBufferFactoryL0_0 : public ICRCFactory
 {
 public:
-    ~CRCBufferFactory() override = default;
+    ~CRCBufferFactoryL0_0() override = default;
     virtual std::unique_ptr<ICRCContainable> Create(IDESC& desc) const override;
 };
 
@@ -68,13 +68,13 @@ public:
     virtual const UINT& GetByteWidth() const override { return dMem->GetByteWidth(); }
     virtual const void GetDesc(D3D11_BUFFER_DESC* dst) override;
 
-    friend class CRCBufferFactory;
+    friend class CRCBufferFactoryL0_0;
 };
 
-class CRC_API CRCID3D11BufferFactory : public ICRCFactory
+class CRC_API CRCID3D11BufferFactoryL0_0 : public ICRCFactory
 {
 public:
-    ~CRCID3D11BufferFactory() override = default;
+    ~CRCID3D11BufferFactoryL0_0() override = default;
     virtual std::unique_ptr<ICRCContainable> Create(IDESC& desc) const override;
 };
 
@@ -92,5 +92,5 @@ public:
     virtual const UINT& GetByteWidth() const override;
     virtual const void GetDesc(D3D11_BUFFER_DESC* dst) override;
 
-    friend class CRCID3D11BufferFactory;
+    friend class CRCID3D11BufferFactoryL0_0;
 };

--- a/CuRendCore/CuRendCore/include/CRC_config.h
+++ b/CuRendCore/CuRendCore/include/CRC_config.h
@@ -26,4 +26,22 @@ constexpr const char* C_COLOR_RESET = "\033[0m";
 constexpr const char* C_TAG = "[CuRendCore]";
 constexpr const char* C_TAG_END = "[------ END]";
 
-}
+constexpr int ERROR_CREATE_WINDOW = 0x0001;
+constexpr int ERROR_SHOW_WINDOW = 0x0002;
+constexpr int ERROR_CREATE_SCENE = 0x0003;
+constexpr int ERROR_CREATE_CONTAINER = 0x0004;
+constexpr int ERROR_ADD_TO_CONTAINER = 0x0005;
+
+
+} // namespace CRC
+
+enum class CRC_API CRC_FEATURE_LEVEL : unsigned int
+{
+    L0_0 = 0,
+};
+
+enum class CRC_API CRC_RENDER_MODE : unsigned int
+{
+    CUDA = 0,
+    D3D11 = 1,
+};

--- a/CuRendCore/CuRendCore/include/CRC_device.cuh
+++ b/CuRendCore/CuRendCore/include/CRC_device.cuh
@@ -1,6 +1,9 @@
 ﻿#pragma once
 
 #include "CRC_config.h"
+#include "CRC_factory.h"
+#include "CRC_texture.cuh"
+#include "CRC_buffer.cuh"
 
 #include <d3d11.h>
 #include <wrl/client.h>
@@ -9,23 +12,58 @@
 #include "cuda_runtime.h"
 #include "device_launch_parameters.h"
 
-class ICRCDevice
+class CRC_API CRC_DEVICE_DESC : public IDESC
+{
+public:
+    CRC_DEVICE_DESC(Microsoft::WRL::ComPtr<ID3D11Device>& device) : d3d11Device_(device) {}
+    ~CRC_DEVICE_DESC() override = default;
+
+    Microsoft::WRL::ComPtr<ID3D11Device>& d3d11Device_;
+
+    CRC_FEATURE_LEVEL featureLevel_ = CRC_FEATURE_LEVEL::L0_0;
+    CRC_RENDER_MODE renderMode_ = CRC_RENDER_MODE::CUDA;
+};
+
+class CRC_API ICRCDevice
 {
 public:
     virtual ~ICRCDevice() = default;
+    virtual Microsoft::WRL::ComPtr<ID3D11Device>& GetD3D11Device() = 0;
+
+    virtual HRESULT CreateBuffer(CRC_BUFFER_DESC& desc, std::unique_ptr<ICRCContainable>& buffer) = 0;
+    virtual HRESULT CreateTexture2D(CRC_TEXTURE2D_DESC& desc, std::unique_ptr<ICRCContainable>& texture2d) = 0;
 };
 
-class CRCDevice : public ICRCDevice
+class CRC_API CRCDeviceFactoryL0_0 : public ICRCFactory
 {
 public:
-    ~CRCDevice() override = default;
+    ~CRCDeviceFactoryL0_0() override = default;
+    virtual std::unique_ptr<ICRCContainable> Create(IDESC& desc) const override;
 };
 
-class CRCID3D11Device : public ICRCDevice
+class CRC_API CRCDevice : public ICRCDevice, public ICRCContainable
 {
 private:
-    Microsoft::WRL::ComPtr<ID3D11Device> d3d11Device;
+    Microsoft::WRL::ComPtr<ID3D11Device>& d3d11Device;
+
+    const std::unique_ptr<ICRCFactory> bufferFactory = nullptr;
+    const std::unique_ptr<ICRCFactory> texture2DFactory = nullptr;
 
 public:
-    ~CRCID3D11Device() override = default;
+    CRCDevice
+    (
+        Microsoft::WRL::ComPtr<ID3D11Device>& d3d11Device,
+        std::unique_ptr<ICRCFactory> bufferFactory, 
+        std::unique_ptr<ICRCFactory> texture2DFactory
+    )
+    : d3d11Device(d3d11Device)
+    , bufferFactory(std::move(bufferFactory))
+    , texture2DFactory(std::move(texture2DFactory)) {}
+
+    ~CRCDevice() override = default;
+
+    Microsoft::WRL::ComPtr<ID3D11Device>& GetD3D11Device() override { return d3d11Device; }
+
+    HRESULT CreateBuffer(CRC_BUFFER_DESC& desc, std::unique_ptr<ICRCContainable>& buffer) override;
+    HRESULT CreateTexture2D(CRC_TEXTURE2D_DESC& desc, std::unique_ptr<ICRCContainable>& texture2d) override;
 };

--- a/CuRendCore/CuRendCore/include/CRC_funcs.cuh
+++ b/CuRendCore/CuRendCore/include/CRC_funcs.cuh
@@ -29,6 +29,8 @@ class ICRCWinMsgEvent;
 class ICRCDevice;
 class ICRCSwapChain;
 
+class CRC_SWAP_CHAIN_DESC;
+
 namespace CRC
 {
 
@@ -52,14 +54,8 @@ CRC_API HRESULT ShowWindowCRC(HWND& hWnd);
 
 CRC_API HRESULT CreateD3D11DeviceAndSwapChain
 (
-    const HWND& hWnd,
+    CRC_SWAP_CHAIN_DESC& desc,
     Microsoft::WRL::ComPtr<ID3D11Device>& device, Microsoft::WRL::ComPtr<IDXGISwapChain>& swapChain
-);
-
-CRC_API HRESULT CreateCRCDeviceAndSwapChain
-(
-    Microsoft::WRL::ComPtr<ID3D11Device>& d3d11Device, Microsoft::WRL::ComPtr<IDXGISwapChain>& d3d11SwapChain,
-    std::unique_ptr<ICRCDevice>& crcDevice, std::unique_ptr<ICRCSwapChain> crcSwapChain
 );
 
 UINT GetBytesPerPixel(const DXGI_FORMAT& format);

--- a/CuRendCore/CuRendCore/include/CRC_funcs.cuh
+++ b/CuRendCore/CuRendCore/include/CRC_funcs.cuh
@@ -108,11 +108,32 @@ CRC_API void CoutWarning(Args&... args)
     std::cout << std::endl << CRC::C_COLOR_WARNING << CRC::C_TAG_END << CRC::C_COLOR_RESET << std::endl;
 }
 
+HRESULT RegisterCudaResources
+(
+    std::vector<cudaGraphicsResource_t>& cudaResources, const cudaGraphicsRegisterFlags& flags,
+    const UINT& bufferCount, IDXGISwapChain* d3d11SwapChain
+);
 HRESULT RegisterCudaResource
 (
-    std::vector<cudaGraphicsResource_t>& cudaResources, UINT bufferCount,IDXGISwapChain* d3d11SwapChain
+    cudaGraphicsResource_t& cudaResource, const cudaGraphicsRegisterFlags& flags,
+    ID3D11Texture2D* d3d11Texture
 );
-HRESULT UnregisterCudaResource(std::vector<cudaGraphicsResource_t>& cudaResources);
+
+HRESULT UnregisterCudaResources(std::vector<cudaGraphicsResource_t>& cudaResources);
+HRESULT UnregisterCudaResource(cudaGraphicsResource_t& cudaResource);
+
+/**
+ * @brief Un registers all CUDA resources from the swap chain.
+ * At this time, if SwapChain has been presented at least once, unregistering the buffer 
+ * that will become the next display buffer directly will cause windows to freeze, 
+ * so unregister after presenting and shifting the buffer.
+ * The error is probably due to the fact that it is tied to RenderTarget, etc.
+ */
+HRESULT UnregisterCudaResourcesAtSwapChain
+(
+    std::vector<cudaGraphicsResource_t>& cudaResources, 
+    Microsoft::WRL::ComPtr<IDXGISwapChain>& d3d11SwapChain, UINT& frameIndex, const UINT& bufferCount
+);
 
 HRESULT MapCudaResource(cudaGraphicsResource_t& cudaResource, cudaStream_t stream = 0);
 HRESULT UnmapCudaResource(cudaGraphicsResource_t& cudaResource, cudaStream_t stream = 0);

--- a/CuRendCore/CuRendCore/include/CRC_funcs.cuh
+++ b/CuRendCore/CuRendCore/include/CRC_funcs.cuh
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <string_view>
 #include <initializer_list>
+#include <vector>
 
 #include <d3d11.h>
 #include <wrl/client.h>
@@ -106,5 +107,15 @@ CRC_API void CoutWarning(Args&... args)
     (void)std::initializer_list<int>{(std::cout << args << " ", 0)...};
     std::cout << std::endl << CRC::C_COLOR_WARNING << CRC::C_TAG_END << CRC::C_COLOR_RESET << std::endl;
 }
+
+HRESULT RegisterCudaResource
+(
+    std::vector<cudaGraphicsResource_t>& cudaResources, UINT bufferCount,IDXGISwapChain* d3d11SwapChain
+);
+HRESULT UnregisterCudaResource(std::vector<cudaGraphicsResource_t>& cudaResources);
+
+HRESULT MapCudaResource(cudaGraphicsResource_t& cudaResource, cudaStream_t stream = 0);
+HRESULT UnmapCudaResource(cudaGraphicsResource_t& cudaResource, cudaStream_t stream = 0);
+cudaArray_t GetCudaMappedArray(cudaGraphicsResource_t& cudaResource);
 
 }

--- a/CuRendCore/CuRendCore/include/CRC_funcs.cuh
+++ b/CuRendCore/CuRendCore/include/CRC_funcs.cuh
@@ -25,6 +25,9 @@ class ICRCContainer;
 
 class ICRCWinMsgEvent;
 
+class ICRCDevice;
+class ICRCSwapChain;
+
 namespace CRC
 {
 
@@ -45,11 +48,17 @@ std::unique_ptr<T> UniqueAs(std::unique_ptr<S>& source)
 }
 
 CRC_API HRESULT ShowWindowCRC(HWND& hWnd);
-CRC_API HRESULT CreateDeviceAndSwapChain
+
+CRC_API HRESULT CreateD3D11DeviceAndSwapChain
 (
     const HWND& hWnd,
-    Microsoft::WRL::ComPtr<ID3D11Device>& device,
-    Microsoft::WRL::ComPtr<IDXGISwapChain>& swapChain
+    Microsoft::WRL::ComPtr<ID3D11Device>& device, Microsoft::WRL::ComPtr<IDXGISwapChain>& swapChain
+);
+
+CRC_API HRESULT CreateCRCDeviceAndSwapChain
+(
+    Microsoft::WRL::ComPtr<ID3D11Device>& d3d11Device, Microsoft::WRL::ComPtr<IDXGISwapChain>& d3d11SwapChain,
+    std::unique_ptr<ICRCDevice>& crcDevice, std::unique_ptr<ICRCSwapChain> crcSwapChain
 );
 
 UINT GetBytesPerPixel(const DXGI_FORMAT& format);

--- a/CuRendCore/CuRendCore/include/CRC_memory.cuh
+++ b/CuRendCore/CuRendCore/include/CRC_memory.cuh
@@ -17,7 +17,8 @@ class CRC_API ICRCMem
 public:
     virtual ~ICRCMem() = default;
 
-    virtual operator void* const() = 0;
+    virtual void* Get() = 0;
+    virtual void*& GetPtr() = 0;
 
     virtual const UINT& GetByteWidth() const = 0;
     virtual const UINT& GetPitch() const = 0;
@@ -39,7 +40,8 @@ public:
     CRCHostMem() = default;
     ~CRCHostMem() override;
 
-    operator void* const() override { return ptr_; }
+    virtual void* Get() override { return ptr_; }
+    virtual void*& GetPtr() override { return ptr_; }
 
     const UINT& GetByteWidth() const override { return byteWidth_; }
     const UINT& GetPitch() const override { return pitch_; }
@@ -61,7 +63,8 @@ public:
     CRCDeviceMem() = default;
     ~CRCDeviceMem() override;
 
-    operator void* const() override { return ptr_; }
+    virtual void* Get() override { return ptr_; }
+    virtual void*& GetPtr() override { return ptr_; }
 
     const UINT& GetByteWidth() const override { return byteWidth_; }
     const UINT& GetPitch() const override { return pitch_; }

--- a/CuRendCore/CuRendCore/include/CRC_pch.h
+++ b/CuRendCore/CuRendCore/include/CRC_pch.h
@@ -27,13 +27,13 @@
 #include "cuda_runtime.h"
 #include "device_launch_parameters.h"
 
-namespace CRC
-{
+// namespace CRC
+// {
 
-constexpr int ERROR_CREATE_WINDOW = 0x0001;
-constexpr int ERROR_SHOW_WINDOW = 0x0002;
-constexpr int ERROR_CREATE_SCENE = 0x0003;
-constexpr int ERROR_CREATE_CONTAINER = 0x0004;
-constexpr int ERROR_ADD_TO_CONTAINER = 0x0005;
+// // constexpr int ERROR_CREATE_WINDOW = 0x0001;
+// // constexpr int ERROR_SHOW_WINDOW = 0x0002;
+// // constexpr int ERROR_CREATE_SCENE = 0x0003;
+// // constexpr int ERROR_CREATE_CONTAINER = 0x0004;
+// // constexpr int ERROR_ADD_TO_CONTAINER = 0x0005;
 
-}
+// }

--- a/CuRendCore/CuRendCore/include/CRC_resource.cuh
+++ b/CuRendCore/CuRendCore/include/CRC_resource.cuh
@@ -20,7 +20,7 @@ class CRC_API ICRCCudaResource : public ICRCResource
 {
 public:
     virtual ~ICRCCudaResource() = default;
-    virtual void* const GetMem() const = 0;
+    virtual void* const Get() const = 0;
 };
 
 class CRC_API ICRCD3D11Resource : public ICRCResource

--- a/CuRendCore/CuRendCore/include/CRC_swap_chain.cuh
+++ b/CuRendCore/CuRendCore/include/CRC_swap_chain.cuh
@@ -24,11 +24,7 @@ public:
     ~CRC_SWAP_CHAIN_DESC() override = default;
 
     Microsoft::WRL::ComPtr<IDXGISwapChain>& GetD3D11SwapChain() { return d3d11SwapChain_; }
-
-    UINT& BufferCount() { return desc_.BufferCount; }
-    DXGI_USAGE& BufferUsage() { return desc_.BufferUsage; }
-    DXGI_RATIONAL& RefreshRate() { return desc_.BufferDesc.RefreshRate; }
-    DXGI_SWAP_EFFECT& SwapEffect() { return desc_.SwapEffect; }
+    DXGI_SWAP_CHAIN_DESC& GetDxgiDesc() { return desc_; }
 };
 
 class CRC_API ICRCSwapChain
@@ -44,6 +40,8 @@ public:
     ) = 0;
 
     virtual HRESULT Present(UINT syncInterval, UINT flags) = 0;
+
+    virtual HRESULT GetDesc(DXGI_SWAP_CHAIN_DESC *pDesc) = 0;
 };
 
 class CRC_API CRCSwapChainFactoryL0_0 : public ICRCFactory
@@ -59,9 +57,7 @@ private:
     Microsoft::WRL::ComPtr<IDXGISwapChain>& d3d11SwapChain_;
 
     UINT bufferCount_;
-    const DXGI_USAGE bufferUsage_;
-    const DXGI_RATIONAL refreshRate_;
-    const DXGI_SWAP_EFFECT swapEffect_;
+    DXGI_RATIONAL refreshRate_;
 
     std::vector<cudaGraphicsResource_t> cudaResources_;
     UINT frameIndex_ = 0;
@@ -72,7 +68,7 @@ public:
     CRCSwapChain
     (
         Microsoft::WRL::ComPtr<IDXGISwapChain>& d3d11SwapChain,
-        UINT bufferCount, DXGI_USAGE bufferUsage, DXGI_RATIONAL refreshRate, DXGI_SWAP_EFFECT swapEffect
+        const DXGI_SWAP_CHAIN_DESC& desc
     );
 
     ~CRCSwapChain() override;
@@ -86,6 +82,8 @@ public:
     ) override;
 
     HRESULT Present(UINT syncInterval, UINT flags) override;
+
+    HRESULT GetDesc(DXGI_SWAP_CHAIN_DESC* pDesc) override;
 };
 
 class CRC_API CRCIDXGISwapChainFactoryL0_0 : public ICRCFactory
@@ -113,4 +111,6 @@ public:
     ) override;
 
     HRESULT Present(UINT syncInterval, UINT flags) override;
+
+    HRESULT GetDesc(DXGI_SWAP_CHAIN_DESC* pDesc) override;
 };

--- a/CuRendCore/CuRendCore/include/CRC_swap_chain.cuh
+++ b/CuRendCore/CuRendCore/include/CRC_swap_chain.cuh
@@ -1,0 +1,99 @@
+﻿#pragma once
+
+#include "CRC_config.h"
+#include "CRC_factory.h"
+#include "CRC_texture.cuh"
+
+#include <d3d11.h>
+#include <wrl/client.h>
+#include <cuda_d3d11_interop.h>
+
+#include "cuda_runtime.h"
+#include "device_launch_parameters.h"
+
+class CRC_API CRC_SWAP_CHAIN_DESC : public IDESC
+{
+private:
+    DXGI_SWAP_CHAIN_DESC desc_ = {};
+    Microsoft::WRL::ComPtr<IDXGISwapChain>& d3d11SwapChain;
+
+public:
+    CRC_SWAP_CHAIN_DESC(Microsoft::WRL::ComPtr<IDXGISwapChain>& d3d11SwapChain) : d3d11SwapChain(d3d11SwapChain) {}
+    ~CRC_SWAP_CHAIN_DESC() override = default;
+
+    Microsoft::WRL::ComPtr<IDXGISwapChain>& GetD3D11SwapChain() { return d3d11SwapChain; }
+
+    UINT& BufferCount() { return desc_.BufferCount; }
+    DXGI_USAGE& BufferUsage() { return desc_.BufferUsage; }
+    DXGI_RATIONAL& RefreshRate() { return desc_.BufferDesc.RefreshRate; }
+    DXGI_SWAP_EFFECT& SwapEffect() { return desc_.SwapEffect; }
+};
+
+class CRC_API ICRCSwapChain
+{
+public:
+    virtual ~ICRCSwapChain() = default;
+    virtual Microsoft::WRL::ComPtr<IDXGISwapChain>& GetD3D11SwapChain() = 0;
+
+    virtual HRESULT GetBuffer(UINT buffer, std::unique_ptr<ICRCContainable>& texture) = 0;
+    virtual HRESULT ResizeBuffers
+    (
+        UINT bufferCount, UINT width, UINT height, DXGI_FORMAT newFormat, UINT swapChainFlags
+    ) = 0;
+
+    virtual HRESULT Present(UINT syncInterval, UINT flags) = 0;
+};
+
+class CRC_API CRCSwapChainFactoryL0_0 : public ICRCFactory
+{
+public:
+    ~CRCSwapChainFactoryL0_0() override = default;
+    virtual std::unique_ptr<ICRCContainable> Create(IDESC& desc) const override;
+};
+
+class CRC_API CRCSwapChain : public ICRCContainable, public ICRCSwapChain
+{
+private:
+    Microsoft::WRL::ComPtr<IDXGISwapChain>& d3d11SwapChain;
+
+public:
+    CRCSwapChain(Microsoft::WRL::ComPtr<IDXGISwapChain>& d3d11SwapChain) : d3d11SwapChain(d3d11SwapChain) {}
+    ~CRCSwapChain() override = default;
+
+    Microsoft::WRL::ComPtr<IDXGISwapChain>& GetD3D11SwapChain() override { return d3d11SwapChain; }
+
+    HRESULT GetBuffer(UINT buffer, std::unique_ptr<ICRCContainable>& texture) override;
+    HRESULT ResizeBuffers
+    (
+        UINT bufferCount, UINT width, UINT height, DXGI_FORMAT newFormat, UINT swapChainFlags
+    ) override;
+
+    HRESULT Present(UINT syncInterval, UINT flags) override;
+};
+
+class CRC_API CRCIDXGISwapChainFactoryL0_0 : public ICRCFactory
+{
+public:
+    ~CRCIDXGISwapChainFactoryL0_0() override = default;
+    virtual std::unique_ptr<ICRCContainable> Create(IDESC& desc) const override;
+};
+
+class CRC_API CRCIDXGISwapChain : public ICRCContainable, public ICRCSwapChain
+{
+private:
+    Microsoft::WRL::ComPtr<IDXGISwapChain>& d3d11SwapChain;
+
+public:
+    CRCIDXGISwapChain(Microsoft::WRL::ComPtr<IDXGISwapChain> d3d11SwapChain) : d3d11SwapChain(d3d11SwapChain) {}
+    ~CRCIDXGISwapChain() override = default;
+
+    Microsoft::WRL::ComPtr<IDXGISwapChain>& GetD3D11SwapChain() override { return d3d11SwapChain; }
+
+    HRESULT GetBuffer(UINT buffer, std::unique_ptr<ICRCContainable>& texture) override;
+    HRESULT ResizeBuffers
+    (
+        UINT bufferCount, UINT width, UINT height, DXGI_FORMAT newFormat, UINT swapChainFlags
+    ) override;
+
+    HRESULT Present(UINT syncInterval, UINT flags) override;
+};

--- a/CuRendCore/CuRendCore/include/CRC_swap_chain.cuh
+++ b/CuRendCore/CuRendCore/include/CRC_swap_chain.cuh
@@ -17,13 +17,12 @@ class CRC_API CRC_SWAP_CHAIN_DESC : public IDESC
 {
 private:
     DXGI_SWAP_CHAIN_DESC desc_ = {};
-    Microsoft::WRL::ComPtr<IDXGISwapChain>& d3d11SwapChain_;
 
 public:
     CRC_SWAP_CHAIN_DESC(Microsoft::WRL::ComPtr<IDXGISwapChain>& d3d11SwapChain) : d3d11SwapChain_(d3d11SwapChain) {}
     ~CRC_SWAP_CHAIN_DESC() override = default;
 
-    Microsoft::WRL::ComPtr<IDXGISwapChain>& GetD3D11SwapChain() { return d3d11SwapChain_; }
+    Microsoft::WRL::ComPtr<IDXGISwapChain>& d3d11SwapChain_;
     DXGI_SWAP_CHAIN_DESC& GetDxgiDesc() { return desc_; }
 };
 

--- a/CuRendCore/CuRendCore/include/CRC_texture.cuh
+++ b/CuRendCore/CuRendCore/include/CRC_texture.cuh
@@ -64,20 +64,20 @@ class CRC_API CRCTexture2D : public ICRCContainable, public ICRCCudaResource, pu
 {
 private:
     D3D11_TEXTURE2D_DESC desc_ = {};
-    std::unique_ptr<ICRCMem> dMem = nullptr;
+    std::unique_ptr<ICRCMem> dMem_ = nullptr;
 
 public:
-    CRCTexture2D() = default;
+    CRCTexture2D();
+    CRCTexture2D(CRC_TEXTURE2D_DESC& desc);
     ~CRCTexture2D() override = default;
 
-    virtual void* const GetMem() const override { return dMem.get(); }
+    virtual void* const Get() const { return dMem_->Get(); }
+    virtual void*& GetPtr() { return dMem_->GetPtr(); }
 
-    virtual const UINT& GetByteWidth() const override { return dMem->GetByteWidth(); }
-    virtual const UINT& GetPitch() const override { return dMem->GetPitch(); }
-    virtual const UINT& GetSlicePitch() const override { return dMem->GetSlicePitch(); }
+    virtual const UINT& GetByteWidth() const override { return dMem_->GetByteWidth(); }
+    virtual const UINT& GetPitch() const override { return dMem_->GetPitch(); }
+    virtual const UINT& GetSlicePitch() const override { return dMem_->GetSlicePitch(); }
     virtual const void GetDesc(D3D11_TEXTURE2D_DESC* dst) override;
-
-    friend class CRCTexture2DFactoryL0_0;
 };
 
 class CRC_API CRCID3D11Texture2DFactoryL0_0 : public ICRCFactory
@@ -91,18 +91,17 @@ class CRC_API CRCID3D11Texture2D : public ICRCContainable, public ICRCD3D11Resou
 {
 private:
     D3D11_TEXTURE2D_DESC desc_ = {};
-    Microsoft::WRL::ComPtr<ID3D11Texture2D> d3d11Texture2D;
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> d3d11Texture2D_;
 
 public:
     CRCID3D11Texture2D() = default;
     ~CRCID3D11Texture2D() override = default;
 
-    virtual Microsoft::WRL::ComPtr<ID3D11Resource>& GetResource() override;
+    virtual Microsoft::WRL::ComPtr<ID3D11Resource>& GetResource();
+    virtual Microsoft::WRL::ComPtr<ID3D11Texture2D>& Get() { return d3d11Texture2D_; }
 
     virtual const UINT& GetByteWidth() const override;
     virtual const UINT& GetPitch() const override;
     virtual const UINT& GetSlicePitch() const override;
     virtual const void GetDesc(D3D11_TEXTURE2D_DESC* dst) override;
-
-    friend class CRCID3D11Texture2DFactoryL0_0;
 };

--- a/CuRendCore/CuRendCore/include/CRC_texture.cuh
+++ b/CuRendCore/CuRendCore/include/CRC_texture.cuh
@@ -20,10 +20,10 @@ private:
     D3D11_SUBRESOURCE_DATA initialData_ = {};
 
 public:
-    CRC_TEXTURE2D_DESC(Microsoft::WRL::ComPtr<ID3D11Device>& device) : device_(device) {}
+    CRC_TEXTURE2D_DESC(Microsoft::WRL::ComPtr<ID3D11Device>& device) : d3d11Device_(device) {}
     ~CRC_TEXTURE2D_DESC() override = default;
 
-    Microsoft::WRL::ComPtr<ID3D11Device>& device_;
+    Microsoft::WRL::ComPtr<ID3D11Device>& d3d11Device_;
 
     D3D11_TEXTURE2D_DESC& Desc() { return desc_; }
     D3D11_SUBRESOURCE_DATA& InitialData() { return initialData_; }
@@ -53,10 +53,10 @@ public:
     virtual const void GetDesc(D3D11_TEXTURE2D_DESC* dst) = 0;
 };
 
-class CRC_API CRCTexture2DFactory : public ICRCFactory
+class CRC_API CRCTexture2DFactoryL0_0 : public ICRCFactory
 {
 public:
-    ~CRCTexture2DFactory() override = default;
+    ~CRCTexture2DFactoryL0_0() override = default;
     virtual std::unique_ptr<ICRCContainable> Create(IDESC& desc) const override;
 };
 
@@ -77,13 +77,13 @@ public:
     virtual const UINT& GetSlicePitch() const override { return dMem->GetSlicePitch(); }
     virtual const void GetDesc(D3D11_TEXTURE2D_DESC* dst) override;
 
-    friend class CRCTexture2DFactory;
+    friend class CRCTexture2DFactoryL0_0;
 };
 
-class CRC_API CRCID3D11Texture2DFactory : public ICRCFactory
+class CRC_API CRCID3D11Texture2DFactoryL0_0 : public ICRCFactory
 {
 public:
-    ~CRCID3D11Texture2DFactory() override = default;
+    ~CRCID3D11Texture2DFactoryL0_0() override = default;
     virtual std::unique_ptr<ICRCContainable> Create(IDESC& desc) const override;
 };
 
@@ -104,5 +104,5 @@ public:
     virtual const UINT& GetSlicePitch() const override;
     virtual const void GetDesc(D3D11_TEXTURE2D_DESC* dst) override;
 
-    friend class CRCID3D11Texture2DFactory;
+    friend class CRCID3D11Texture2DFactoryL0_0;
 };

--- a/CuRendCore/CuRendCore/include/CRC_window.h
+++ b/CuRendCore/CuRendCore/include/CRC_window.h
@@ -56,6 +56,6 @@ public:
 
     HWND hWnd_ = nullptr;
 
-    Microsoft::WRL::ComPtr<ID3D11Device> device_ = nullptr;
+    Microsoft::WRL::ComPtr<ID3D11Device> d3d11Device_ = nullptr;
     Microsoft::WRL::ComPtr<IDXGISwapChain> swapChain_ = nullptr;
 };

--- a/CuRendCore/CuRendCore/include/CuRendCore.h
+++ b/CuRendCore/CuRendCore/include/CuRendCore.h
@@ -18,3 +18,7 @@
 
 #include "CRC_buffer.cuh"
 #include "CRC_texture.cuh"
+
+#include "CRC_device.cuh"
+#include "CRC_device_context.cuh"
+#include "CRC_swap_chain.cuh"

--- a/CuRendCore/CuRendCore/src/CRC_buffer.cu
+++ b/CuRendCore/CuRendCore/src/CRC_buffer.cu
@@ -8,22 +8,30 @@ std::unique_ptr<ICRCContainable> CRCBufferFactoryL0_0::Create(IDESC &desc) const
     CRC_BUFFER_DESC* bufferDesc = CRC::As<CRC_BUFFER_DESC>(&desc);
     if (!bufferDesc) return nullptr;
 
-    std::unique_ptr<CRCBuffer> buffer = std::make_unique<CRCBuffer>();
-    buffer->dMem = std::make_unique<CRCDeviceMem>();
+    std::unique_ptr<CRCBuffer> buffer = std::make_unique<CRCBuffer>(*bufferDesc);
+    return buffer;
+}
 
-    buffer->dMem->Malloc(bufferDesc->ByteWidth(), 1, 1);
+CRCBuffer::CRCBuffer()
+{
+    dMem_ = std::make_unique<CRCDeviceMem>();
+}
+
+CRCBuffer::CRCBuffer(CRC_BUFFER_DESC &desc)
+{
+    dMem_ = std::make_unique<CRCDeviceMem>();
+
+    dMem_->Malloc(desc.ByteWidth(), 1, 1);
     
-    if (bufferDesc->SysMem())
+    if (desc.SysMem())
     {
         CRC::CheckCuda(cudaMemcpy
         (
-            buffer->dMem.get(), bufferDesc->SysMem(), bufferDesc->ByteWidth(), cudaMemcpyHostToDevice
+            dMem_.get(), desc.SysMem(), desc.ByteWidth(), cudaMemcpyHostToDevice
         ));
     }
 
-    buffer->desc_ = bufferDesc->Desc();
-
-    return buffer;
+    desc_ = desc.Desc();
 }
 
 const void CRCBuffer::GetDesc(D3D11_BUFFER_DESC *dst)
@@ -45,7 +53,7 @@ std::unique_ptr<ICRCContainable> CRCID3D11BufferFactoryL0_0::Create(IDESC &desc)
 
     HRESULT hr = bufferDesc->d3d11Device_->CreateBuffer
     (
-        &bufferDesc->Desc(), initialData, buffer->d3d11Buffer.GetAddressOf()
+        &bufferDesc->Desc(), initialData, buffer->Get().GetAddressOf()
     );
     if (FAILED(hr)) return nullptr;
 
@@ -55,7 +63,7 @@ std::unique_ptr<ICRCContainable> CRCID3D11BufferFactoryL0_0::Create(IDESC &desc)
 Microsoft::WRL::ComPtr<ID3D11Resource> &CRCID3D11Buffer::GetResource()
 {
     Microsoft::WRL::ComPtr<ID3D11Resource> resource;
-    d3d11Buffer.As(&resource);
+    d3d11Buffer_.As(&resource);
 
     return resource;
 }
@@ -63,12 +71,12 @@ Microsoft::WRL::ComPtr<ID3D11Resource> &CRCID3D11Buffer::GetResource()
 const UINT &CRCID3D11Buffer::GetByteWidth() const
 {
     D3D11_BUFFER_DESC desc;
-    d3d11Buffer->GetDesc(&desc);
+    d3d11Buffer_->GetDesc(&desc);
 
     return desc.ByteWidth;
 }
 
 const void CRCID3D11Buffer::GetDesc(D3D11_BUFFER_DESC *dst)
 {
-    d3d11Buffer->GetDesc(dst);
+    d3d11Buffer_->GetDesc(dst);
 }

--- a/CuRendCore/CuRendCore/src/CRC_buffer.cu
+++ b/CuRendCore/CuRendCore/src/CRC_buffer.cu
@@ -3,7 +3,7 @@
 
 #include "CRC_buffer.cuh"
 
-std::unique_ptr<ICRCContainable> CRCBufferFactory::Create(IDESC &desc) const
+std::unique_ptr<ICRCContainable> CRCBufferFactoryL0_0::Create(IDESC &desc) const
 {
     CRC_BUFFER_DESC* bufferDesc = CRC::As<CRC_BUFFER_DESC>(&desc);
     if (!bufferDesc) return nullptr;
@@ -31,7 +31,7 @@ const void CRCBuffer::GetDesc(D3D11_BUFFER_DESC *dst)
     std::memcpy(dst, &desc_, sizeof(D3D11_BUFFER_DESC));
 }
 
-std::unique_ptr<ICRCContainable> CRCID3D11BufferFactory::Create(IDESC &desc) const
+std::unique_ptr<ICRCContainable> CRCID3D11BufferFactoryL0_0::Create(IDESC &desc) const
 {
     CRC_BUFFER_DESC* bufferDesc = CRC::As<CRC_BUFFER_DESC>(&desc);
     if (!bufferDesc) return nullptr;
@@ -41,9 +41,9 @@ std::unique_ptr<ICRCContainable> CRCID3D11BufferFactory::Create(IDESC &desc) con
     D3D11_SUBRESOURCE_DATA* initialData = nullptr;
     if (bufferDesc->SysMem()) initialData = &bufferDesc->InitialData();
 
-    if (!bufferDesc->device_) throw std::runtime_error("Device not set.");
+    if (!bufferDesc->d3d11Device_) throw std::runtime_error("Device not set.");
 
-    HRESULT hr = bufferDesc->device_->CreateBuffer
+    HRESULT hr = bufferDesc->d3d11Device_->CreateBuffer
     (
         &bufferDesc->Desc(), initialData, buffer->d3d11Buffer.GetAddressOf()
     );

--- a/CuRendCore/CuRendCore/src/CRC_device.cu
+++ b/CuRendCore/CuRendCore/src/CRC_device.cu
@@ -1,1 +1,53 @@
-﻿
+﻿#include "CRC_pch.h"
+#include "CRC_funcs.cuh"
+
+#include "CRC_device.cuh"
+
+std::unique_ptr<ICRCContainable> CRCDeviceFactoryL0_0::Create(IDESC &desc) const
+{
+    CRC_DEVICE_DESC* deviceDesc = CRC::As<CRC_DEVICE_DESC>(&desc);
+    if (!deviceDesc) return nullptr;
+
+    std::unique_ptr<CRCDevice> device;
+    if (deviceDesc->renderMode_ == CRC_RENDER_MODE::CUDA)
+    {
+        device = std::make_unique<CRCDevice>
+        (
+            deviceDesc->d3d11Device_,
+            std::make_unique<CRCBufferFactoryL0_0>(),
+            std::make_unique<CRCTexture2DFactoryL0_0>()
+        );
+    }
+    else if (deviceDesc->renderMode_ == CRC_RENDER_MODE::D3D11)
+    {
+        device = std::make_unique<CRCDevice>
+        (
+            deviceDesc->d3d11Device_,
+            std::make_unique<CRCID3D11BufferFactoryL0_0>(),
+            std::make_unique<CRCID3D11Texture2DFactoryL0_0>()
+        );
+    }
+    else
+    {
+#ifndef NDEBUG
+        CRC::CoutError("Unknown render mode.");
+#endif
+        throw std::runtime_error("Unknown render mode.");
+    }
+
+    return device;
+}
+
+HRESULT CRCDevice::CreateBuffer(CRC_BUFFER_DESC& desc, std::unique_ptr<ICRCContainable> &buffer)
+{
+    buffer = bufferFactory->Create(desc);
+    if (!buffer) return E_FAIL;
+    return S_OK;
+}
+
+HRESULT CRCDevice::CreateTexture2D(CRC_TEXTURE2D_DESC &desc, std::unique_ptr<ICRCContainable> &texture2d)
+{
+    texture2d = texture2DFactory->Create(desc);
+    if (!texture2d) return E_FAIL;
+    return S_OK;
+}

--- a/CuRendCore/CuRendCore/src/CRC_funcs.cu
+++ b/CuRendCore/CuRendCore/src/CRC_funcs.cu
@@ -22,26 +22,9 @@ HRESULT CRC::ShowWindowCRC(HWND& hWnd)
 
 CRC_API HRESULT CRC::CreateD3D11DeviceAndSwapChain
 (
-    const HWND& hWnd,
+    CRC_SWAP_CHAIN_DESC& desc,
     Microsoft::WRL::ComPtr<ID3D11Device> &device, Microsoft::WRL::ComPtr<IDXGISwapChain> &swapChain
 ){
-    // Setup swap chain
-    DXGI_SWAP_CHAIN_DESC sd;
-    ZeroMemory(&sd, sizeof(sd));
-    sd.BufferCount = 2;
-    sd.BufferDesc.Width = 0;
-    sd.BufferDesc.Height = 0;
-    sd.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    sd.BufferDesc.RefreshRate.Numerator = 60;
-    sd.BufferDesc.RefreshRate.Denominator = 1;
-    sd.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
-    sd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    sd.OutputWindow = hWnd;
-    sd.SampleDesc.Count = 1;
-    sd.SampleDesc.Quality = 0;
-    sd.Windowed = TRUE;
-    sd.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
-
     UINT createDeviceFlags = 0;
     D3D_FEATURE_LEVEL featureLevel;
     const D3D_FEATURE_LEVEL featureLevelArray[2] = { D3D_FEATURE_LEVEL_11_0, D3D_FEATURE_LEVEL_10_0, };
@@ -49,7 +32,7 @@ CRC_API HRESULT CRC::CreateD3D11DeviceAndSwapChain
     HRESULT hr = D3D11CreateDeviceAndSwapChain
     (
         nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, createDeviceFlags, featureLevelArray, 2, 
-        D3D11_SDK_VERSION, &sd, &swapChain, &device, &featureLevel, nullptr
+        D3D11_SDK_VERSION, &desc.GetDxgiDesc(), &swapChain, &device, &featureLevel, nullptr
     );
 
     if (hr == DXGI_ERROR_UNSUPPORTED) // Try high-performance WARP software driver if hardware is not available.
@@ -57,19 +40,11 @@ CRC_API HRESULT CRC::CreateD3D11DeviceAndSwapChain
         hr = D3D11CreateDeviceAndSwapChain
         (
             nullptr, D3D_DRIVER_TYPE_WARP, nullptr, createDeviceFlags, featureLevelArray, 2, 
-            D3D11_SDK_VERSION, &sd, &swapChain, &device, &featureLevel, nullptr
+            D3D11_SDK_VERSION, &desc.GetDxgiDesc(), &swapChain, &device, &featureLevel, nullptr
         );
     }
 
     return hr;
-}
-
-CRC_API HRESULT CRC::CreateCRCDeviceAndSwapChain
-(
-    Microsoft::WRL::ComPtr<ID3D11Device> &d3d11Device, Microsoft::WRL::ComPtr<IDXGISwapChain> &d3d11SwapChain, 
-    std::unique_ptr<ICRCDevice> &crcDevice, std::unique_ptr<ICRCSwapChain> crcSwapChain
-){
-    return E_NOTIMPL;
 }
 
 UINT CRC::GetBytesPerPixel(const DXGI_FORMAT &format)

--- a/CuRendCore/CuRendCore/src/CRC_funcs.cu
+++ b/CuRendCore/CuRendCore/src/CRC_funcs.cu
@@ -87,19 +87,35 @@ HRESULT CRC::RegisterCudaResources
     for (UINT i = 0; i < bufferCountFromDesc; i++)
     {
         HRESULT hr = d3d11SwapChain->GetBuffer(i, __uuidof(ID3D11Texture2D), (void**)&buffers[i]);
-        if (FAILED(hr)) return hr;
+        if (FAILED(hr))
+        {
+#ifndef NDEBUG
+            CoutError("Failed to get buffers from DXGI swap chain.");
+#endif
+            return E_FAIL;
+        }
 
         cudaError_t err = cudaGraphicsD3D11RegisterResource
         (
             &cudaResources[i], buffers[i], flags
         );
-        if (err != cudaSuccess) return E_FAIL;
+        if (err != cudaSuccess)
+        {
+#ifndef NDEBUG
+            CoutError("Failed to register CUDA resources.");
+#endif
+            return E_FAIL;
+        }
     }
 
     for (int i = 0; i < bufferCountFromDesc; i++)
     {
         buffers[i]->Release();
     }
+
+#ifndef NDEBUG
+    Cout("Registered CUDA resources.");
+#endif
 
     return S_OK;
 }
@@ -110,7 +126,17 @@ HRESULT CRC::RegisterCudaResource
     ID3D11Texture2D *d3d11Texture
 ){
     cudaError_t err = cudaGraphicsD3D11RegisterResource(&cudaResource, d3d11Texture, flags);
-    if (err != cudaSuccess) return E_FAIL;
+    if (err != cudaSuccess)
+    {
+#ifndef NDEBUG
+        CoutError("Failed to register CUDA resource.");
+#endif
+        return E_FAIL;
+    }
+
+#ifndef NDEBUG
+    Cout("Registered CUDA resource.");
+#endif
 
     return S_OK;
 }
@@ -120,8 +146,18 @@ HRESULT CRC::UnregisterCudaResources(std::vector<cudaGraphicsResource_t> &cudaRe
     for (int i = 0; i < cudaResources.size(); ++i) 
     {
         cudaError_t err = cudaGraphicsUnregisterResource(cudaResources[i]);
-        if (err != cudaSuccess) return E_FAIL;
+        if (err != cudaSuccess)
+        {
+#ifndef NDEBUG
+            CoutError("Failed to unregister CUDA resources.");
+#endif
+            return E_FAIL;
+        }
     }
+
+#ifndef NDEBUG
+    Cout("Unregistered CUDA resources.");
+#endif
 
     return S_OK;
 }
@@ -129,7 +165,17 @@ HRESULT CRC::UnregisterCudaResources(std::vector<cudaGraphicsResource_t> &cudaRe
 HRESULT CRC::UnregisterCudaResource(cudaGraphicsResource_t &cudaResource)
 {
     cudaError_t err = cudaGraphicsUnregisterResource(cudaResource);
-    if (err != cudaSuccess) return E_FAIL;
+    if (err != cudaSuccess)
+    {
+#ifndef NDEBUG
+        CoutError("Failed to unregister CUDA resource.");
+#endif
+        return E_FAIL;
+    }
+
+#ifndef NDEBUG
+    Cout("Unregistered CUDA resource.");
+#endif
 
     return S_OK;
 }
@@ -144,14 +190,30 @@ HRESULT CRC::UnregisterCudaResourcesAtSwapChain
         if (i == frameIndex) continue;
 
         cudaError_t err = cudaGraphicsUnregisterResource(cudaResources[i]);
-        if (err != cudaSuccess) return E_FAIL;
+        if (err != cudaSuccess)
+        {
+#ifndef NDEBUG
+            CoutError("Failed to unregister CUDA resources in swap chain.");
+#endif
+            return E_FAIL;
+        }
     }
 
     d3d11SwapChain->Present(0, 0);
     cudaError_t err = cudaGraphicsUnregisterResource(cudaResources[frameIndex]);
-    if (err != cudaSuccess) return E_FAIL;
+    if (err != cudaSuccess)
+    {
+#ifndef NDEBUG
+        CoutError("Failed to unregister CUDA resources in swap chain.");
+#endif
+        return E_FAIL;
+    }
 
     frameIndex = (frameIndex + 1) % bufferCount;
+
+#ifndef NDEBUG
+    Cout("Unregistered CUDA resources in swap chain.");
+#endif
 
     return S_OK;
 }
@@ -159,7 +221,17 @@ HRESULT CRC::UnregisterCudaResourcesAtSwapChain
 HRESULT CRC::MapCudaResource(cudaGraphicsResource_t& cudaResource, cudaStream_t stream)
 {
     cudaError_t err = cudaGraphicsMapResources(1, &cudaResource, stream);
-    if (err != cudaSuccess) return E_FAIL;
+    if (err != cudaSuccess)
+    {
+#ifndef NDEBUG
+        CoutError("Failed to map CUDA resource.");
+#endif
+        return E_FAIL;
+    }
+
+#ifndef NDEBUG
+    Cout("Mapped CUDA resource.");
+#endif
 
     return S_OK;
 }
@@ -167,7 +239,17 @@ HRESULT CRC::MapCudaResource(cudaGraphicsResource_t& cudaResource, cudaStream_t 
 HRESULT CRC::UnmapCudaResource(cudaGraphicsResource_t& cudaResource, cudaStream_t stream)
 {
     cudaError_t err = cudaGraphicsUnmapResources(1, &cudaResource, stream);
-    if (err != cudaSuccess) return E_FAIL;
+    if (err != cudaSuccess)
+    {
+#ifndef NDEBUG
+        CoutError("Failed to unmap CUDA resource.");
+#endif
+        return E_FAIL;
+    }
+
+#ifndef NDEBUG
+    Cout("Unmapped CUDA resource.");
+#endif
 
     return S_OK;
 }
@@ -176,7 +258,13 @@ cudaArray_t CRC::GetCudaMappedArray(cudaGraphicsResource_t& cudaResource)
 {
     cudaArray_t cudaArray;
     cudaError_t err = cudaGraphicsSubResourceGetMappedArray(&cudaArray, cudaResource, 0, 0);
-    if (err != cudaSuccess) return nullptr;
+    if (err != cudaSuccess)
+    {
+#ifndef NDEBUG
+        CoutError("Failed to get CUDA mapped array.");
+#endif
+        return nullptr;
+    }
 
     return cudaArray;
 }

--- a/CuRendCore/CuRendCore/src/CRC_funcs.cu
+++ b/CuRendCore/CuRendCore/src/CRC_funcs.cu
@@ -7,6 +7,9 @@
 #include "CRC_container.h"
 #include "CRC_event.h"
 
+#include "CRC_device.cuh"
+#include "CRC_swap_chain.cuh"
+
 HRESULT CRC::ShowWindowCRC(HWND& hWnd)
 {
     if (!hWnd) return E_FAIL;
@@ -17,7 +20,7 @@ HRESULT CRC::ShowWindowCRC(HWND& hWnd)
     return S_OK;
 }
 
-CRC_API HRESULT CRC::CreateDeviceAndSwapChain
+CRC_API HRESULT CRC::CreateD3D11DeviceAndSwapChain
 (
     const HWND& hWnd,
     Microsoft::WRL::ComPtr<ID3D11Device> &device, Microsoft::WRL::ComPtr<IDXGISwapChain> &swapChain
@@ -59,6 +62,14 @@ CRC_API HRESULT CRC::CreateDeviceAndSwapChain
     }
 
     return hr;
+}
+
+CRC_API HRESULT CRC::CreateCRCDeviceAndSwapChain
+(
+    Microsoft::WRL::ComPtr<ID3D11Device> &d3d11Device, Microsoft::WRL::ComPtr<IDXGISwapChain> &d3d11SwapChain, 
+    std::unique_ptr<ICRCDevice> &crcDevice, std::unique_ptr<ICRCSwapChain> crcSwapChain
+){
+    return E_NOTIMPL;
 }
 
 UINT CRC::GetBytesPerPixel(const DXGI_FORMAT &format)

--- a/CuRendCore/CuRendCore/src/CRC_memory.cu
+++ b/CuRendCore/CuRendCore/src/CRC_memory.cu
@@ -27,7 +27,6 @@ void CRCHostMem::Malloc(const UINT &byteWidth, const UINT &pitch, const UINT &sl
 #ifndef NDEBUG
     CRC::Cout
     (
-        "\n",
         "Host memory allocated.", "\n", 
         "ByteWidth :", byteWidth_, "\n",
         "Pitch :", pitch_, "\n",
@@ -82,7 +81,6 @@ void CRCDeviceMem::Malloc(const UINT &byteWidth, const UINT &pitch, const UINT &
 #ifndef NDEBUG
     CRC::Cout
     (
-        "\n",
         "Device memory allocated.", "\n", 
         "ByteWidth :", byteWidth_, "\n",
         "Pitch :", pitch_, "\n",

--- a/CuRendCore/CuRendCore/src/CRC_swap_chain.cu
+++ b/CuRendCore/CuRendCore/src/CRC_swap_chain.cu
@@ -8,23 +8,121 @@ std::unique_ptr<ICRCContainable> CRCSwapChainFactoryL0_0::Create(IDESC &desc) co
     CRC_SWAP_CHAIN_DESC* swapChainDesc = CRC::As<CRC_SWAP_CHAIN_DESC>(&desc);
     if (!swapChainDesc) return nullptr;
 
-    std::unique_ptr<CRCSwapChain> swapChain = std::make_unique<CRCSwapChain>(swapChainDesc->GetD3D11SwapChain());
+    std::unique_ptr<CRCSwapChain> swapChain = std::make_unique<CRCSwapChain>
+    (
+        swapChainDesc->GetD3D11SwapChain(),
+        swapChainDesc->BufferCount(),
+        swapChainDesc->BufferUsage(),
+        swapChainDesc->RefreshRate(),
+        swapChainDesc->SwapEffect()
+    );
+
     return swapChain;
 }
 
-HRESULT CRCSwapChain::GetBuffer(UINT buffer, std::unique_ptr<ICRCContainable> &texture)
+CRCSwapChain::CRCSwapChain
+(
+    Microsoft::WRL::ComPtr<IDXGISwapChain> &d3d11SwapChain, 
+    UINT bufferCount, DXGI_USAGE bufferUsage, DXGI_RATIONAL refreshRate, DXGI_SWAP_EFFECT swapEffect
+) 
+: d3d11SwapChain_(d3d11SwapChain)
+, bufferCount_(bufferCount), bufferUsage_(bufferUsage), refreshRate_(refreshRate), swapEffect_(swapEffect)
 {
-    return E_NOTIMPL;
+    HRESULT hr = CRC::RegisterCudaResource(cudaResources_, bufferCount, d3d11SwapChain_.Get());
+    if (FAILED(hr))
+    {
+#ifndef NDEBUG
+        CRC::CoutError("Failed to create CRCSwapChain by registering CUDA resources.");
+#endif
+        throw std::runtime_error("Failed to create CRCSwapChain by registering CUDA resources.");
+    }
+
+    hr = CRC::MapCudaResource(cudaResources_[frameIndex_]);
+    if (FAILED(hr))
+    {
+#ifndef NDEBUG
+        CRC::CoutError("Failed to create CRCSwapChain by mapping CUDA resources.");
+#endif
+        throw std::runtime_error("Failed to create CRCSwapChain by mapping CUDA resources.");
+    }
+
+    cudaArray_t backBufferArray = CRC::GetCudaMappedArray(cudaResources_[frameIndex_]);
+    if (!backBufferArray)
+    {
+#ifndef NDEBUG
+        CRC::CoutError("Failed to create CRCSwapChain by getting CUDA mapped array.");
+#endif
+        throw std::runtime_error("Failed to create CRCSwapChain by getting CUDA mapped array.");
+    }
+
+    backBuffer_ = std::make_unique<CRCTexture2D>();
+    backBuffer_->GetPtr() = (void*)backBufferArray;
 }
 
-HRESULT CRCSwapChain::ResizeBuffers(UINT bufferCount, UINT width, UINT height, DXGI_FORMAT newFormat, UINT swapChainFlags)
+CRCSwapChain::~CRCSwapChain()
 {
-    return E_NOTIMPL;
+    CRC::UnmapCudaResource(cudaResources_[frameIndex_]);
+    CRC::UnregisterCudaResource(cudaResources_);
+
+    backBuffer_->GetPtr() = nullptr;
+    backBuffer_.reset();
+}
+
+HRESULT CRCSwapChain::GetBuffer(UINT buffer, ICRCTexture2D *&texture)
+{
+    texture = backBuffer_.get();
+    if (!texture) return E_INVALIDARG;
+    return S_OK;
+}
+
+HRESULT CRCSwapChain::ResizeBuffers
+(
+    UINT bufferCount, UINT width, UINT height, DXGI_FORMAT newFormat, UINT swapChainFlags
+){
+    HRESULT hr = S_OK;
+    hr = CRC::UnmapCudaResource(cudaResources_[frameIndex_]);
+    if (FAILED(hr)) return hr;
+
+    hr = CRC::UnregisterCudaResource(cudaResources_);
+    if (FAILED(hr)) return hr;
+
+    frameIndex_ = 0;
+    bufferCount_ = bufferCount;
+
+    hr = d3d11SwapChain_->ResizeBuffers(bufferCount, width, height, newFormat, swapChainFlags);
+    if (FAILED(hr)) return hr;
+
+    hr = CRC::RegisterCudaResource(cudaResources_, bufferCount, d3d11SwapChain_.Get());
+    if (FAILED(hr)) return hr;
+
+    hr = CRC::MapCudaResource(cudaResources_[frameIndex_]);
+    if (FAILED(hr)) return hr;
+
+    cudaArray_t backBufferArray = CRC::GetCudaMappedArray(cudaResources_[frameIndex_]);
+    if (!backBufferArray) return E_FAIL;
+
+    backBuffer_->GetPtr() = (void*)backBufferArray;
 }
 
 HRESULT CRCSwapChain::Present(UINT syncInterval, UINT flags)
 {
-    return E_NOTIMPL;
+    HRESULT hr = CRC::UnmapCudaResource(cudaResources_[frameIndex_]);
+    if (FAILED(hr)) return hr;
+
+    hr = d3d11SwapChain_->Present(syncInterval, flags);
+    if (FAILED(hr)) return hr;
+
+    frameIndex_ = (frameIndex_ + 1) % bufferCount_;
+
+    hr = CRC::MapCudaResource(cudaResources_[frameIndex_]);
+    if (FAILED(hr)) return hr;
+
+    cudaArray_t backBufferArray = CRC::GetCudaMappedArray(cudaResources_[frameIndex_]);
+    if (!backBufferArray) return E_FAIL;
+
+    backBuffer_->GetPtr() = (void*)backBufferArray;
+
+    return S_OK;
 }
 
 std::unique_ptr<ICRCContainable> CRCIDXGISwapChainFactoryL0_0::Create(IDESC &desc) const
@@ -40,17 +138,22 @@ std::unique_ptr<ICRCContainable> CRCIDXGISwapChainFactoryL0_0::Create(IDESC &des
     return swapChain;
 }
 
-HRESULT CRCIDXGISwapChain::GetBuffer(UINT buffer, std::unique_ptr<ICRCContainable> &texture)
+HRESULT CRCIDXGISwapChain::GetBuffer(UINT buffer, ICRCTexture2D *&texture)
 {
-    return E_NOTIMPL;
+    CRCID3D11Texture2D* backBuffer = CRC::As<CRCID3D11Texture2D>(texture);
+    if (!backBuffer) return E_INVALIDARG;
+
+    d3d11SwapChain_->GetBuffer(buffer, __uuidof(ID3D11Texture2D), &backBuffer->Get());
 }
 
-HRESULT CRCIDXGISwapChain::ResizeBuffers(UINT bufferCount, UINT width, UINT height, DXGI_FORMAT newFormat, UINT swapChainFlags)
-{
-    return E_NOTIMPL;
+HRESULT CRCIDXGISwapChain::ResizeBuffers
+(
+    UINT bufferCount, UINT width, UINT height, DXGI_FORMAT newFormat, UINT swapChainFlags
+){
+    return d3d11SwapChain_->ResizeBuffers(bufferCount, width, height, newFormat, swapChainFlags);
 }
 
 HRESULT CRCIDXGISwapChain::Present(UINT syncInterval, UINT flags)
 {
-    return E_NOTIMPL;
+    return d3d11SwapChain_->Present(syncInterval, flags);
 }

--- a/CuRendCore/CuRendCore/src/CRC_swap_chain.cu
+++ b/CuRendCore/CuRendCore/src/CRC_swap_chain.cu
@@ -1,0 +1,56 @@
+﻿#include "CRC_pch.h"
+#include "CRC_funcs.cuh"
+
+#include "CRC_swap_chain.cuh"
+
+std::unique_ptr<ICRCContainable> CRCSwapChainFactoryL0_0::Create(IDESC &desc) const
+{
+    CRC_SWAP_CHAIN_DESC* swapChainDesc = CRC::As<CRC_SWAP_CHAIN_DESC>(&desc);
+    if (!swapChainDesc) return nullptr;
+
+    std::unique_ptr<CRCSwapChain> swapChain = std::make_unique<CRCSwapChain>(swapChainDesc->GetD3D11SwapChain());
+    return swapChain;
+}
+
+HRESULT CRCSwapChain::GetBuffer(UINT buffer, std::unique_ptr<ICRCContainable> &texture)
+{
+    return E_NOTIMPL;
+}
+
+HRESULT CRCSwapChain::ResizeBuffers(UINT bufferCount, UINT width, UINT height, DXGI_FORMAT newFormat, UINT swapChainFlags)
+{
+    return E_NOTIMPL;
+}
+
+HRESULT CRCSwapChain::Present(UINT syncInterval, UINT flags)
+{
+    return E_NOTIMPL;
+}
+
+std::unique_ptr<ICRCContainable> CRCIDXGISwapChainFactoryL0_0::Create(IDESC &desc) const
+{
+    CRC_SWAP_CHAIN_DESC* swapChainDesc = CRC::As<CRC_SWAP_CHAIN_DESC>(&desc);
+    if (!swapChainDesc) return nullptr;
+
+    std::unique_ptr<CRCIDXGISwapChain> swapChain = std::make_unique<CRCIDXGISwapChain>
+    (
+        swapChainDesc->GetD3D11SwapChain()
+    );
+
+    return swapChain;
+}
+
+HRESULT CRCIDXGISwapChain::GetBuffer(UINT buffer, std::unique_ptr<ICRCContainable> &texture)
+{
+    return E_NOTIMPL;
+}
+
+HRESULT CRCIDXGISwapChain::ResizeBuffers(UINT bufferCount, UINT width, UINT height, DXGI_FORMAT newFormat, UINT swapChainFlags)
+{
+    return E_NOTIMPL;
+}
+
+HRESULT CRCIDXGISwapChain::Present(UINT syncInterval, UINT flags)
+{
+    return E_NOTIMPL;
+}

--- a/CuRendCore/CuRendCore/src/CRC_swap_chain.cu
+++ b/CuRendCore/CuRendCore/src/CRC_swap_chain.cu
@@ -93,6 +93,8 @@ HRESULT CRCSwapChain::ResizeBuffers
     hr = d3d11SwapChain_->ResizeBuffers(bufferCount, width, height, newFormat, swapChainFlags);
     if (FAILED(hr)) return hr;
 
+    frameIndex_ = 0;
+
     hr = CRC::RegisterCudaResources
     (
         cudaResources_, cudaGraphicsRegisterFlagsNone, 
@@ -107,6 +109,8 @@ HRESULT CRCSwapChain::ResizeBuffers
     if (!backBufferArray) return E_FAIL;
 
     backBuffer_->GetPtr() = (void*)backBufferArray;
+
+    return S_OK;
 }
 
 HRESULT CRCSwapChain::Present(UINT syncInterval, UINT flags)

--- a/CuRendCore/CuRendCore/src/CRC_swap_chain.cu
+++ b/CuRendCore/CuRendCore/src/CRC_swap_chain.cu
@@ -10,7 +10,7 @@ std::unique_ptr<ICRCContainable> CRCSwapChainFactoryL0_0::Create(IDESC &desc) co
 
     std::unique_ptr<CRCSwapChain> swapChain = std::make_unique<CRCSwapChain>
     (
-        swapChainDesc->GetD3D11SwapChain(), swapChainDesc->GetDxgiDesc()
+        swapChainDesc->d3d11SwapChain_, swapChainDesc->GetDxgiDesc()
     );
 
     return swapChain;
@@ -127,7 +127,7 @@ std::unique_ptr<ICRCContainable> CRCIDXGISwapChainFactoryL0_0::Create(IDESC &des
 
     std::unique_ptr<CRCIDXGISwapChain> swapChain = std::make_unique<CRCIDXGISwapChain>
     (
-        swapChainDesc->GetD3D11SwapChain()
+        swapChainDesc->d3d11SwapChain_
     );
 
     return swapChain;

--- a/CuRendCore/CuRendCore/src/CRC_texture.cu
+++ b/CuRendCore/CuRendCore/src/CRC_texture.cu
@@ -3,7 +3,7 @@
 
 #include "CRC_texture.cuh"
 
-std::unique_ptr<ICRCContainable> CRCTexture2DFactory::Create(IDESC &desc) const
+std::unique_ptr<ICRCContainable> CRCTexture2DFactoryL0_0::Create(IDESC &desc) const
 {
     CRC_TEXTURE2D_DESC* textureDesc = CRC::As<CRC_TEXTURE2D_DESC>(&desc);
     if (!textureDesc) return nullptr;
@@ -36,7 +36,7 @@ const void CRCTexture2D::GetDesc(D3D11_TEXTURE2D_DESC *dst)
     std::memcpy(dst, &desc_, sizeof(D3D11_TEXTURE2D_DESC));
 }
 
-std::unique_ptr<ICRCContainable> CRCID3D11Texture2DFactory::Create(IDESC &desc) const
+std::unique_ptr<ICRCContainable> CRCID3D11Texture2DFactoryL0_0::Create(IDESC &desc) const
 {
     CRC_TEXTURE2D_DESC* textureDesc = CRC::As<CRC_TEXTURE2D_DESC>(&desc);
     if (!textureDesc) return nullptr;
@@ -46,9 +46,9 @@ std::unique_ptr<ICRCContainable> CRCID3D11Texture2DFactory::Create(IDESC &desc) 
     D3D11_SUBRESOURCE_DATA* initialData = nullptr;
     if (textureDesc->SysMem()) initialData = &textureDesc->InitialData();
 
-    if (!textureDesc->device_) throw std::runtime_error("Device not set.");
+    if (!textureDesc->d3d11Device_) throw std::runtime_error("Device not set.");
 
-    HRESULT hr = textureDesc->device_->CreateTexture2D
+    HRESULT hr = textureDesc->d3d11Device_->CreateTexture2D
     (
         &textureDesc->Desc(), initialData, texture->d3d11Texture2D.GetAddressOf()
     );

--- a/CuRendCore/CuRendCore_Test/device_test.cpp
+++ b/CuRendCore/CuRendCore_Test/device_test.cpp
@@ -59,3 +59,128 @@ TEST(CuRendCore, CreateD3D11DeviceAndSwapChain)
     EXPECT_NE(device.Get(), nullptr);
     EXPECT_NE(swapChain.Get(), nullptr);
 }
+
+TEST(CuRendCor, CreateCRCSwapChain)
+{
+    // Create window attributes.
+    std::unique_ptr<ICRCContainable> windowAttr;
+    {
+        CRC_WINDOW_DESC desc = {};
+        desc.wcex_.lpszClassName = L"CreateCRCSwapChain";
+        desc.wcex_.lpfnWndProc = WindowProc;
+        desc.name_ = L"CreateCRCSwapChain";
+        desc.hInstance = GetModuleHandle(NULL);
+
+        CRCWindowFactory windowFactory;
+        windowAttr = windowFactory.Create(desc);
+    }
+    // Show window.
+    HRESULT hr = CRC::ShowWindowCRC(CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_);
+
+    Microsoft::WRL::ComPtr<ID3D11Device> device;
+    Microsoft::WRL::ComPtr<IDXGISwapChain> swapChain;
+
+    CRC::CreateD3D11DeviceAndSwapChain(CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_, device, swapChain);
+
+    // Create CRC swap chain.
+    std::unique_ptr<ICRCContainable> swapChainAttr;
+    {
+        CRC_SWAP_CHAIN_DESC desc(swapChain);
+        desc.BufferCount() = 2;
+        desc.BufferUsage() = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+        desc.RefreshRate().Numerator = 60;
+        desc.RefreshRate().Denominator = 1;
+        desc.SwapEffect() = DXGI_SWAP_EFFECT_DISCARD;
+
+        CRCSwapChainFactoryL0_0 swapChainFactory;
+        swapChainAttr = swapChainFactory.Create(desc);
+    }
+
+    EXPECT_NE(swapChainAttr.get(), nullptr);
+}
+
+TEST(CuRendCore, GetSwapChainBuffer)
+{
+    // Create window attributes.
+    std::unique_ptr<ICRCContainable> windowAttr;
+    {
+        CRC_WINDOW_DESC desc = {};
+        desc.wcex_.lpszClassName = L"GetSwapChainBuffer";
+        desc.wcex_.lpfnWndProc = WindowProc;
+        desc.name_ = L"GetSwapChainBuffer";
+        desc.hInstance = GetModuleHandle(NULL);
+
+        CRCWindowFactory windowFactory;
+        windowAttr = windowFactory.Create(desc);
+    }
+    // Show window.
+    HRESULT hr = CRC::ShowWindowCRC(CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_);
+
+    Microsoft::WRL::ComPtr<ID3D11Device> device;
+    Microsoft::WRL::ComPtr<IDXGISwapChain> swapChain;
+
+    CRC::CreateD3D11DeviceAndSwapChain(CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_, device, swapChain);
+
+    // Create CRC swap chain.
+    std::unique_ptr<ICRCContainable> crcSwapChain;
+    {
+        CRC_SWAP_CHAIN_DESC desc(swapChain);
+        desc.BufferCount() = 2;
+        desc.BufferUsage() = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+        desc.RefreshRate().Numerator = 60;
+        desc.RefreshRate().Denominator = 1;
+        desc.SwapEffect() = DXGI_SWAP_EFFECT_DISCARD;
+
+        CRCSwapChainFactoryL0_0 swapChainFactory;
+        crcSwapChain = swapChainFactory.Create(desc);
+    }
+
+    ICRCTexture2D* backBuffer = nullptr;
+    CRC::As<CRCSwapChain>(crcSwapChain.get())->GetBuffer(0, backBuffer);
+
+    EXPECT_NE(backBuffer, nullptr);
+}
+
+// TEST(CuRendCore, PresentSwapChain)
+// {
+//     // Create window attributes.
+//     std::unique_ptr<ICRCContainable> windowAttr;
+//     {
+//         CRC_WINDOW_DESC desc = {};
+//         desc.wcex_.lpszClassName = L"PresentSwapChain";
+//         desc.wcex_.lpfnWndProc = WindowProc;
+//         desc.name_ = L"PresentSwapChain";
+//         desc.hInstance = GetModuleHandle(NULL);
+
+//         CRCWindowFactory windowFactory;
+//         windowAttr = windowFactory.Create(desc);
+//     }
+//     // Show window.
+//     HRESULT hr = CRC::ShowWindowCRC(CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_);
+
+//     Microsoft::WRL::ComPtr<ID3D11Device> device;
+//     Microsoft::WRL::ComPtr<IDXGISwapChain> swapChain;
+
+//     CRC::CreateD3D11DeviceAndSwapChain(CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_, device, swapChain);
+
+//     // Create CRC swap chain.
+//     std::unique_ptr<ICRCContainable> crcSwapChain;
+//     {
+//         CRC_SWAP_CHAIN_DESC desc(swapChain);
+//         desc.BufferCount() = 2;
+//         desc.BufferUsage() = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+//         desc.RefreshRate().Numerator = 60;
+//         desc.RefreshRate().Denominator = 1;
+//         desc.SwapEffect() = DXGI_SWAP_EFFECT_DISCARD;
+
+//         CRCSwapChainFactoryL0_0 swapChainFactory;
+//         crcSwapChain = swapChainFactory.Create(desc);
+//     }
+
+//     ICRCTexture2D* backBuffer = nullptr;
+//     CRC::As<CRCSwapChain>(crcSwapChain.get())->GetBuffer(0, backBuffer);
+
+//     CRC::As<CRCSwapChain>(crcSwapChain.get())->Present(0, 0);
+
+//     EXPECT_NE(backBuffer, nullptr);
+// }

--- a/CuRendCore/CuRendCore_Test/device_test.cpp
+++ b/CuRendCore/CuRendCore_Test/device_test.cpp
@@ -53,7 +53,26 @@ TEST(CuRendCore, CreateD3D11DeviceAndSwapChain)
 
     Microsoft::WRL::ComPtr<ID3D11Device> device;
     Microsoft::WRL::ComPtr<IDXGISwapChain> swapChain;
-    CRC::CreateD3D11DeviceAndSwapChain(CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_, device, swapChain);
+    CRC_SWAP_CHAIN_DESC swapChainDesc(swapChain);
+    {
+        DXGI_SWAP_CHAIN_DESC& dxgiDesc = swapChainDesc.GetDxgiDesc();
+        ZeroMemory(&dxgiDesc, sizeof(DXGI_SWAP_CHAIN_DESC));
+        dxgiDesc.BufferCount = 2;
+        dxgiDesc.BufferDesc.Width = 0;
+        dxgiDesc.BufferDesc.Height = 0;
+        dxgiDesc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+        dxgiDesc.BufferDesc.RefreshRate.Numerator = 60;
+        dxgiDesc.BufferDesc.RefreshRate.Denominator = 1;
+        dxgiDesc.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
+        dxgiDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+        dxgiDesc.OutputWindow = CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_;
+        dxgiDesc.SampleDesc.Count = 1;
+        dxgiDesc.SampleDesc.Quality = 0;
+        dxgiDesc.Windowed = TRUE;
+        dxgiDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
+
+        CRC::CreateD3D11DeviceAndSwapChain(swapChainDesc, device, swapChain);
+    }
 
     EXPECT_NE(device.Get(), nullptr);
     EXPECT_NE(swapChain.Get(), nullptr);
@@ -78,20 +97,32 @@ TEST(CuRendCor, CreateCRCSwapChain)
 
     Microsoft::WRL::ComPtr<ID3D11Device> device;
     Microsoft::WRL::ComPtr<IDXGISwapChain> swapChain;
-    CRC::CreateD3D11DeviceAndSwapChain(CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_, device, swapChain);
+    CRC_SWAP_CHAIN_DESC swapChainDesc(swapChain);
+    {
+        DXGI_SWAP_CHAIN_DESC& dxgiDesc = swapChainDesc.GetDxgiDesc();
+        ZeroMemory(&dxgiDesc, sizeof(DXGI_SWAP_CHAIN_DESC));
+        dxgiDesc.BufferCount = 2;
+        dxgiDesc.BufferDesc.Width = 0;
+        dxgiDesc.BufferDesc.Height = 0;
+        dxgiDesc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+        dxgiDesc.BufferDesc.RefreshRate.Numerator = 60;
+        dxgiDesc.BufferDesc.RefreshRate.Denominator = 1;
+        dxgiDesc.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
+        dxgiDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+        dxgiDesc.OutputWindow = CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_;
+        dxgiDesc.SampleDesc.Count = 1;
+        dxgiDesc.SampleDesc.Quality = 0;
+        dxgiDesc.Windowed = TRUE;
+        dxgiDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
+
+        CRC::CreateD3D11DeviceAndSwapChain(swapChainDesc, device, swapChain);
+    }
 
     // Create CRC swap chain.
     std::unique_ptr<ICRCContainable> swapChainAttr;
     {
-        CRC_SWAP_CHAIN_DESC desc(swapChain);
-        desc.BufferCount() = 2;
-        desc.BufferUsage() = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-        desc.RefreshRate().Numerator = 60;
-        desc.RefreshRate().Denominator = 1;
-        desc.SwapEffect() = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
-
         CRCSwapChainFactoryL0_0 swapChainFactory;
-        swapChainAttr = swapChainFactory.Create(desc);
+        swapChainAttr = swapChainFactory.Create(swapChainDesc);
     }
 
     EXPECT_NE(swapChainAttr.get(), nullptr);
@@ -116,20 +147,32 @@ TEST(CuRendCore, GetSwapChainBuffer)
 
     Microsoft::WRL::ComPtr<ID3D11Device> device;
     Microsoft::WRL::ComPtr<IDXGISwapChain> swapChain;
-    CRC::CreateD3D11DeviceAndSwapChain(CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_, device, swapChain);
+    CRC_SWAP_CHAIN_DESC swapChainDesc(swapChain);
+    {
+        DXGI_SWAP_CHAIN_DESC& dxgiDesc = swapChainDesc.GetDxgiDesc();
+        ZeroMemory(&dxgiDesc, sizeof(DXGI_SWAP_CHAIN_DESC));
+        dxgiDesc.BufferCount = 2;
+        dxgiDesc.BufferDesc.Width = 0;
+        dxgiDesc.BufferDesc.Height = 0;
+        dxgiDesc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+        dxgiDesc.BufferDesc.RefreshRate.Numerator = 60;
+        dxgiDesc.BufferDesc.RefreshRate.Denominator = 1;
+        dxgiDesc.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
+        dxgiDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+        dxgiDesc.OutputWindow = CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_;
+        dxgiDesc.SampleDesc.Count = 1;
+        dxgiDesc.SampleDesc.Quality = 0;
+        dxgiDesc.Windowed = TRUE;
+        dxgiDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
+
+        CRC::CreateD3D11DeviceAndSwapChain(swapChainDesc, device, swapChain);
+    }
 
     // Create CRC swap chain.
     std::unique_ptr<ICRCContainable> crcSwapChain;
     {
-        CRC_SWAP_CHAIN_DESC desc(swapChain);
-        desc.BufferCount() = 2;
-        desc.BufferUsage() = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-        desc.RefreshRate().Numerator = 60;
-        desc.RefreshRate().Denominator = 1;
-        desc.SwapEffect() = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
-
         CRCSwapChainFactoryL0_0 swapChainFactory;
-        crcSwapChain = swapChainFactory.Create(desc);
+        crcSwapChain = swapChainFactory.Create(swapChainDesc);
     }
 
     ICRCTexture2D* backBuffer = nullptr;
@@ -157,20 +200,32 @@ TEST(CuRendCore, PresentSwapChain)
 
     Microsoft::WRL::ComPtr<ID3D11Device> device;
     Microsoft::WRL::ComPtr<IDXGISwapChain> swapChain;
-    CRC::CreateD3D11DeviceAndSwapChain(CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_, device, swapChain);
+    CRC_SWAP_CHAIN_DESC swapChainDesc(swapChain);
+    {
+        DXGI_SWAP_CHAIN_DESC& dxgiDesc = swapChainDesc.GetDxgiDesc();
+        ZeroMemory(&dxgiDesc, sizeof(DXGI_SWAP_CHAIN_DESC));
+        dxgiDesc.BufferCount = 2;
+        dxgiDesc.BufferDesc.Width = 0;
+        dxgiDesc.BufferDesc.Height = 0;
+        dxgiDesc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+        dxgiDesc.BufferDesc.RefreshRate.Numerator = 60;
+        dxgiDesc.BufferDesc.RefreshRate.Denominator = 1;
+        dxgiDesc.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
+        dxgiDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+        dxgiDesc.OutputWindow = CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_;
+        dxgiDesc.SampleDesc.Count = 1;
+        dxgiDesc.SampleDesc.Quality = 0;
+        dxgiDesc.Windowed = TRUE;
+        dxgiDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
+
+        CRC::CreateD3D11DeviceAndSwapChain(swapChainDesc, device, swapChain);
+    }
 
     // Create CRC swap chain.
     std::unique_ptr<ICRCContainable> crcSwapChain;
     {
-        CRC_SWAP_CHAIN_DESC desc(swapChain);
-        desc.BufferCount() = 2;
-        desc.BufferUsage() = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-        desc.RefreshRate().Numerator = 60;
-        desc.RefreshRate().Denominator = 1;
-        desc.SwapEffect() = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
-
         CRCSwapChainFactoryL0_0 swapChainFactory;
-        crcSwapChain = swapChainFactory.Create(desc);
+        crcSwapChain = swapChainFactory.Create(swapChainDesc);
     }
 
     ICRCTexture2D* backBuffer = nullptr;
@@ -200,20 +255,32 @@ TEST(CuRendCore, ResizeSwapChain)
 
     Microsoft::WRL::ComPtr<ID3D11Device> device;
     Microsoft::WRL::ComPtr<IDXGISwapChain> swapChain;
-    CRC::CreateD3D11DeviceAndSwapChain(CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_, device, swapChain);
+    CRC_SWAP_CHAIN_DESC swapChainDesc(swapChain);
+    {
+        DXGI_SWAP_CHAIN_DESC& dxgiDesc = swapChainDesc.GetDxgiDesc();
+        ZeroMemory(&dxgiDesc, sizeof(DXGI_SWAP_CHAIN_DESC));
+        dxgiDesc.BufferCount = 2;
+        dxgiDesc.BufferDesc.Width = 0;
+        dxgiDesc.BufferDesc.Height = 0;
+        dxgiDesc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+        dxgiDesc.BufferDesc.RefreshRate.Numerator = 60;
+        dxgiDesc.BufferDesc.RefreshRate.Denominator = 1;
+        dxgiDesc.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
+        dxgiDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+        dxgiDesc.OutputWindow = CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_;
+        dxgiDesc.SampleDesc.Count = 1;
+        dxgiDesc.SampleDesc.Quality = 0;
+        dxgiDesc.Windowed = TRUE;
+        dxgiDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
+
+        CRC::CreateD3D11DeviceAndSwapChain(swapChainDesc, device, swapChain);
+    }
 
     // Create CRC swap chain.
     std::unique_ptr<ICRCContainable> crcSwapChain;
     {
-        CRC_SWAP_CHAIN_DESC desc(swapChain);
-        desc.BufferCount() = 2;
-        desc.BufferUsage() = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-        desc.RefreshRate().Numerator = 60;
-        desc.RefreshRate().Denominator = 1;
-        desc.SwapEffect() = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
-
         CRCSwapChainFactoryL0_0 swapChainFactory;
-        crcSwapChain = swapChainFactory.Create(desc);
+        crcSwapChain = swapChainFactory.Create(swapChainDesc);
     }
 
     ICRCTexture2D* backBuffer = nullptr;

--- a/CuRendCore/CuRendCore_Test/device_test.cpp
+++ b/CuRendCore/CuRendCore_Test/device_test.cpp
@@ -35,16 +35,16 @@ TEST(CuRendCore, CreateAndShowWindow)
     EXPECT_EQ(hr, S_OK);
 }
 
-TEST(CuRendCore, CreateDeviceAndSwapChain) 
+TEST(CuRendCore, CreateD3D11DeviceAndSwapChain) 
 {
     // Create window factory.
     CRCWindowFactory windowFactory;
 
     // Create window attributes.
     CRC_WINDOW_DESC desc = {};
-    desc.wcex_.lpszClassName = L"CreateDeviceAndSwapChain";
+    desc.wcex_.lpszClassName = L"CreateD3D11DeviceAndSwapChain";
     desc.wcex_.lpfnWndProc = WindowProc;
-    desc.name_ = L"CreateDeviceAndSwapChain";
+    desc.name_ = L"CreateD3D11DeviceAndSwapChain";
     desc.hInstance = GetModuleHandle(NULL);
     std::unique_ptr<ICRCContainable> windowAttr = windowFactory.Create(desc);
 
@@ -54,7 +54,7 @@ TEST(CuRendCore, CreateDeviceAndSwapChain)
     Microsoft::WRL::ComPtr<ID3D11Device> device;
     Microsoft::WRL::ComPtr<IDXGISwapChain> swapChain;
 
-    CRC::CreateDeviceAndSwapChain(CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_, device, swapChain);
+    CRC::CreateD3D11DeviceAndSwapChain(CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_, device, swapChain);
 
     EXPECT_NE(device.Get(), nullptr);
     EXPECT_NE(swapChain.Get(), nullptr);

--- a/CuRendCore/CuRendCore_Test/device_test.cpp
+++ b/CuRendCore/CuRendCore_Test/device_test.cpp
@@ -78,7 +78,57 @@ TEST(CuRendCore, CreateD3D11DeviceAndSwapChain)
     EXPECT_NE(swapChain.Get(), nullptr);
 }
 
-TEST(CuRendCor, CreateCRCSwapChain)
+TEST(CuRendCore, CreateCRCDevice)
+{
+    // Create window factory.
+    CRCWindowFactory windowFactory;
+
+    // Create window attributes.
+    CRC_WINDOW_DESC desc = {};
+    desc.wcex_.lpszClassName = L"CreateCRCDevice";
+    desc.wcex_.lpfnWndProc = WindowProc;
+    desc.name_ = L"CreateCRCDevice";
+    desc.hInstance = GetModuleHandle(NULL);
+    std::unique_ptr<ICRCContainable> windowAttr = windowFactory.Create(desc);
+
+    // Show window.
+    HRESULT hr = CRC::ShowWindowCRC(CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_);
+
+    Microsoft::WRL::ComPtr<ID3D11Device> device;
+    Microsoft::WRL::ComPtr<IDXGISwapChain> swapChain;
+    CRC_SWAP_CHAIN_DESC swapChainDesc(swapChain);
+    {
+        DXGI_SWAP_CHAIN_DESC& dxgiDesc = swapChainDesc.GetDxgiDesc();
+        ZeroMemory(&dxgiDesc, sizeof(DXGI_SWAP_CHAIN_DESC));
+        dxgiDesc.BufferCount = 2;
+        dxgiDesc.BufferDesc.Width = 0;
+        dxgiDesc.BufferDesc.Height = 0;
+        dxgiDesc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+        dxgiDesc.BufferDesc.RefreshRate.Numerator = 60;
+        dxgiDesc.BufferDesc.RefreshRate.Denominator = 1;
+        dxgiDesc.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
+        dxgiDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+        dxgiDesc.OutputWindow = CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_;
+        dxgiDesc.SampleDesc.Count = 1;
+        dxgiDesc.SampleDesc.Quality = 0;
+        dxgiDesc.Windowed = TRUE;
+        dxgiDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
+
+        CRC::CreateD3D11DeviceAndSwapChain(swapChainDesc, device, swapChain);
+    }
+
+    std::unique_ptr<ICRCContainable> crcDevice;
+    {
+        CRC_DEVICE_DESC desc(device);
+
+        CRCDeviceFactoryL0_0 deviceFactory;
+        crcDevice = deviceFactory.Create(desc);
+    }
+
+    EXPECT_NE(crcDevice.get(), nullptr);
+}
+
+TEST(CuRendCore, CreateCRCSwapChain)
 {
     // Create window attributes.
     std::unique_ptr<ICRCContainable> windowAttr;

--- a/CuRendCore/CuRendCore_Test/device_test.cpp
+++ b/CuRendCore/CuRendCore_Test/device_test.cpp
@@ -53,7 +53,6 @@ TEST(CuRendCore, CreateD3D11DeviceAndSwapChain)
 
     Microsoft::WRL::ComPtr<ID3D11Device> device;
     Microsoft::WRL::ComPtr<IDXGISwapChain> swapChain;
-
     CRC::CreateD3D11DeviceAndSwapChain(CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_, device, swapChain);
 
     EXPECT_NE(device.Get(), nullptr);
@@ -79,7 +78,6 @@ TEST(CuRendCor, CreateCRCSwapChain)
 
     Microsoft::WRL::ComPtr<ID3D11Device> device;
     Microsoft::WRL::ComPtr<IDXGISwapChain> swapChain;
-
     CRC::CreateD3D11DeviceAndSwapChain(CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_, device, swapChain);
 
     // Create CRC swap chain.
@@ -118,7 +116,6 @@ TEST(CuRendCore, GetSwapChainBuffer)
 
     Microsoft::WRL::ComPtr<ID3D11Device> device;
     Microsoft::WRL::ComPtr<IDXGISwapChain> swapChain;
-
     CRC::CreateD3D11DeviceAndSwapChain(CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_, device, swapChain);
 
     // Create CRC swap chain.
@@ -141,46 +138,45 @@ TEST(CuRendCore, GetSwapChainBuffer)
     EXPECT_NE(backBuffer, nullptr);
 }
 
-// TEST(CuRendCore, PresentSwapChain)
-// {
-//     // Create window attributes.
-//     std::unique_ptr<ICRCContainable> windowAttr;
-//     {
-//         CRC_WINDOW_DESC desc = {};
-//         desc.wcex_.lpszClassName = L"PresentSwapChain";
-//         desc.wcex_.lpfnWndProc = WindowProc;
-//         desc.name_ = L"PresentSwapChain";
-//         desc.hInstance = GetModuleHandle(NULL);
+TEST(CuRendCore, PresentSwapChain)
+{
+    // Create window attributes.
+    std::unique_ptr<ICRCContainable> windowAttr;
+    {
+        CRC_WINDOW_DESC desc = {};
+        desc.wcex_.lpszClassName = L"PresentSwapChain";
+        desc.wcex_.lpfnWndProc = WindowProc;
+        desc.name_ = L"PresentSwapChain";
+        desc.hInstance = GetModuleHandle(NULL);
 
-//         CRCWindowFactory windowFactory;
-//         windowAttr = windowFactory.Create(desc);
-//     }
-//     // Show window.
-//     HRESULT hr = CRC::ShowWindowCRC(CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_);
+        CRCWindowFactory windowFactory;
+        windowAttr = windowFactory.Create(desc);
+    }
+    // Show window.
+    HRESULT hr = CRC::ShowWindowCRC(CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_);
 
-//     Microsoft::WRL::ComPtr<ID3D11Device> device;
-//     Microsoft::WRL::ComPtr<IDXGISwapChain> swapChain;
+    Microsoft::WRL::ComPtr<ID3D11Device> device;
+    Microsoft::WRL::ComPtr<IDXGISwapChain> swapChain;
+    CRC::CreateD3D11DeviceAndSwapChain(CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_, device, swapChain);
 
-//     CRC::CreateD3D11DeviceAndSwapChain(CRC::As<CRCWindowAttr>(windowAttr.get())->hWnd_, device, swapChain);
+    // Create CRC swap chain.
+    std::unique_ptr<ICRCContainable> crcSwapChain;
+    {
+        CRC_SWAP_CHAIN_DESC desc(swapChain);
+        desc.BufferCount() = 2;
+        desc.BufferUsage() = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+        desc.RefreshRate().Numerator = 60;
+        desc.RefreshRate().Denominator = 1;
+        desc.SwapEffect() = DXGI_SWAP_EFFECT_DISCARD;
 
-//     // Create CRC swap chain.
-//     std::unique_ptr<ICRCContainable> crcSwapChain;
-//     {
-//         CRC_SWAP_CHAIN_DESC desc(swapChain);
-//         desc.BufferCount() = 2;
-//         desc.BufferUsage() = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-//         desc.RefreshRate().Numerator = 60;
-//         desc.RefreshRate().Denominator = 1;
-//         desc.SwapEffect() = DXGI_SWAP_EFFECT_DISCARD;
+        CRCSwapChainFactoryL0_0 swapChainFactory;
+        crcSwapChain = swapChainFactory.Create(desc);
+    }
 
-//         CRCSwapChainFactoryL0_0 swapChainFactory;
-//         crcSwapChain = swapChainFactory.Create(desc);
-//     }
+    ICRCTexture2D* backBuffer = nullptr;
+    CRC::As<CRCSwapChain>(crcSwapChain.get())->GetBuffer(0, backBuffer);
 
-//     ICRCTexture2D* backBuffer = nullptr;
-//     CRC::As<CRCSwapChain>(crcSwapChain.get())->GetBuffer(0, backBuffer);
+    hr = CRC::As<CRCSwapChain>(crcSwapChain.get())->Present(0, 0);
 
-//     CRC::As<CRCSwapChain>(crcSwapChain.get())->Present(0, 0);
-
-//     EXPECT_NE(backBuffer, nullptr);
-// }
+    EXPECT_EQ(hr, S_OK);
+}

--- a/CuRendCore/CuRendCore_Test/resource_test.cpp
+++ b/CuRendCore/CuRendCore_Test/resource_test.cpp
@@ -5,7 +5,7 @@ TEST(CuRendCore, CreateBuffer)
 {
     Microsoft::WRL::ComPtr<ID3D11Device> device;
 
-    CRCBufferFactory factory;
+    CRCBufferFactoryL0_0 factory;
     CRC_BUFFER_DESC desc(device);
     desc.ByteWidth() = 1024;
 
@@ -18,7 +18,7 @@ TEST(CuRendCore, CreateTexture2D)
 {
     Microsoft::WRL::ComPtr<ID3D11Device> device;
 
-    CRCTexture2DFactory factory;
+    CRCTexture2DFactoryL0_0 factory;
     CRC_TEXTURE2D_DESC desc(device);
     desc.Width() = 1920;
     desc.Height() = 1080;


### PR DESCRIPTION
## Creating ID3D11Device and IDXGISwapChain
ID3D11Device and IDXGISwapChain are used in CuRendCore as well as drawing in D3D11. Therefore, the following functions are used to create them. The source desc of IDXGISwapChain is used to create SwapChain for CuRendCore.
```C++
CRC_API HRESULT CRC::CreateD3D11DeviceAndSwapChain
(
    CRC_SWAP_CHAIN_DESC& desc,
    Microsoft::WRL::ComPtr<ID3D11Device> &device, Microsoft::WRL::ComPtr<IDXGISwapChain> &swapChain
){
    UINT createDeviceFlags = 0;
    D3D_FEATURE_LEVEL featureLevel;
    const D3D_FEATURE_LEVEL featureLevelArray[2] = { D3D_FEATURE_LEVEL_11_0, D3D_FEATURE_LEVEL_10_0, };

    HRESULT hr = D3D11CreateDeviceAndSwapChain
    (
        nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, createDeviceFlags, featureLevelArray, 2, 
        D3D11_SDK_VERSION, &desc.GetDxgiDesc(), &swapChain, &device, &featureLevel, nullptr
    );

    if (hr == DXGI_ERROR_UNSUPPORTED) // Try high-performance WARP software driver if hardware is not available.
    {
        hr = D3D11CreateDeviceAndSwapChain
        (
            nullptr, D3D_DRIVER_TYPE_WARP, nullptr, createDeviceFlags, featureLevelArray, 2, 
            D3D11_SDK_VERSION, &desc.GetDxgiDesc(), &swapChain, &device, &featureLevel, nullptr
        );
    }

    return hr;
}
```

## By using the Factory pattern, the method of creation can be changed for each version of Device
The main purpose of Device is to create resources for use in rendering, and it has the following interface methods
```C++
class CRC_API ICRCDevice
{
public:
    virtual ~ICRCDevice() = default;
    virtual Microsoft::WRL::ComPtr<ID3D11Device>& GetD3D11Device() = 0;

    virtual HRESULT CreateBuffer(CRC_BUFFER_DESC& desc, std::unique_ptr<ICRCContainable>& buffer) = 0;
    virtual HRESULT CreateTexture2D(CRC_TEXTURE2D_DESC& desc, std::unique_ptr<ICRCContainable>& texture2d) = 0;
};
```

In CuRendCore, ID3D11Device can be obtained because it may be used, and other Create methods use the factory for each type of device. By switching this factory for each version.

## Enabling CUDA to use D3D11 resources to implement SwapChain in CRC
D3D11 resources can be used in the CUDA kernel by registering, mapping, and retrieving arrays as follows
```C++
cudaError_t err;
err = cudaGraphicsD3D11RegisterResource(&cudaResource, d3d11Texture, flags);
err = cudaGraphicsMapResources(1, &cudaResource, stream);

cudaArray_t cudaArray;
err = cudaGraphicsSubResourceGetMappedArray(&cudaArray, cudaResource, 0, 0);
```
They also need to be unmapped and unregistered.
```C++
cudaError_t err;
err = cudaGraphicsUnmapResources(1, &cudaResource, stream);
err = cudaGraphicsUnregisterResource(cudaResource);
```

By doing these things for each buffer of the SwapChain, we can use the CUDA kernel to process the back buffer of the SwapChain and Swap it to the display buffer.

At this point, there are two things to keep in mind
- Do not discard the buffer in SwapEffect.
- The buffer that will be the display buffer in the next present cannot be UnregisterResource.

The first point, "Do not destroy the buffer in SwapEffect," must not be destroyed because it is registered in CUDA and if it is destroyed, processing to the back buffer will not be possible.
The second option, "Buffers that will become display buffers in the next present cannot be UnregisterResource," means that if you want to unregisterresource a buffer that will become a display buffer in the next present, you must release it after it is no longer a display buffer in the present. This may be due to the fact that the buffer cannot be unregistered. This is probably because the back buffer that will become the next display buffer is tied to the render target in some way inside D3D11, so unregistering it will cause an unexpected error. I should pay attention to this because windows froze in my environment.
